### PR TITLE
Ensure logs directory exists for training

### DIFF
--- a/xot_mcts/main.py
+++ b/xot_mcts/main.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 import logging
+import os
 import numpy as np
 import coloredlogs
 from argparse import ArgumentParser
@@ -34,6 +35,7 @@ def main():
     parser.add_argument('--multi_times', type=int, default=500)
     args = parser.parse_args()
 
+    os.makedirs('logs', exist_ok=True)
     logging.basicConfig(filename='logs/%s_%s.log'%(args.env, args.mode), filemode='w', level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')  
     logging.info(args)
 


### PR DESCRIPTION
Running the training example `python main.py --env game24 --mode train --training_env game24/data/train.csv --numMCTSSims 5000 --arenaCompare 100 --numEps 10 --numIters 3` crashes if there is no `logs` directory available.

```
(xot) $ python main.py --env game24 --mode train --training_env game24/data/train.csv --numMCTSSims 5000 --arenaCompare 100 --numEps 10 --numIters 3
Traceback (most recent call last):
  File "main.py", line 86, in <module>
    main()
  File "main.py", line 38, in main
    logging.basicConfig(filename='logs/%s_%s.log'%(args.env, args.mode), filemode='w', level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')  
  File "/home/ak/anaconda3/envs/xot/lib/python3.8/logging/__init__.py", line 1988, in basicConfig
    h = FileHandler(filename, mode)
  File "/home/ak/anaconda3/envs/xot/lib/python3.8/logging/__init__.py", line 1147, in __init__
    StreamHandler.__init__(self, self._open())
  File "/home/ak/anaconda3/envs/xot/lib/python3.8/logging/__init__.py", line 1176, in _open
    return open(self.baseFilename, self.mode, encoding=self.encoding)
FileNotFoundError: [Errno 2] No such file or directory: '/home/ak/workspace/Everything-of-Thoughts-XoT/xot_mcts/logs/game24_train.log'
```

This patch fixes this by creating the directory just before